### PR TITLE
Fix crash linked to multiple calls to complete()

### DIFF
--- a/src/ios/CDVLocalWebServer.m
+++ b/src/ios/CDVLocalWebServer.m
@@ -270,6 +270,7 @@
                     NSString* indexType = [[[NSFileManager defaultManager] attributesOfItemAtPath:indexPath error:NULL] fileType];
                     if ([indexType isEqualToString:NSFileTypeRegular]) {
                         complete([GCDWebServerFileResponse responseWithFile:indexPath]);
+                        return;
                     }
                 }
                 response = [self.server _responseWithContentsOfDirectory:filePath];


### PR DESCRIPTION
Calling the GCDWebServerCompletionBlock argument more than once will result in crash.

See https://github.com/swisspol/GCDWebServer/issues/398